### PR TITLE
As of jQuery 1.9, $.parseJSON throws an error on invalid input, instead ...

### DIFF
--- a/cdc-pentaho5/resources/static/cdc-base.js
+++ b/cdc-pentaho5/resources/static/cdc-base.js
@@ -35,7 +35,9 @@ cdcFunctions.makeRequest = function (url, params) {
             Dashboards.log("Found error: Empty Data");
             return;
           }
-          returnValue = $.parseJSON(data);
+          if (typeof data == "string" && data.length > 0) {
+            returnValue = $.parseJSON(data);  
+          }
           if (!returnValue) {
             returnValue = data;
           }


### PR DESCRIPTION
...of returning null ( an already correct JSON will throw an error ), so we must only try to parse strings.
